### PR TITLE
Avoid date parsing errors

### DIFF
--- a/data/json_files/release_future_date_change.json
+++ b/data/json_files/release_future_date_change.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/peoplepopulationandcommunity/healthandsocialcare/drugusealcoholandsmoking",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_future_provisional_date.json
+++ b/data/json_files/release_future_provisional_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/economy/governmentpublicsectorandtaxes/taxesandrevenue/adhocs/2550taxesandsubsidiesonproductsandproductionbyindustry",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_future_release_date.json
+++ b/data/json_files/release_future_release_date.json
@@ -21,7 +21,7 @@
   "published": true,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2097-07-22T21:31:03Z"
   }],
   "provisional_date": "March 1991"
 }

--- a/data/json_files/release_future_release_date.json
+++ b/data/json_files/release_future_release_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/economy/inflationandpriceindices/bulletins/housepriceindex/april2022",
+  "uri": "/releases/financeandhousingukarmedforcesveteransveteranssurvey2022uk",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_invalid_date_change.json
+++ b/data/json_files/release_invalid_date_change.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/adhocs/2559onslocaloverviewofcreativejobsandcreativeindustriessoutheastofengland2014to2023",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_invalid_provisional_date.json
+++ b/data/json_files/release_invalid_provisional_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/employmentandlabourmarket/peopleinwork/earningsandworkinghours/adhocs/2558annualsurveyofhoursandearningsasheestimatesofgrossannualearningsforregionby2digitoccupation2024",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_invalid_release_date.json
+++ b/data/json_files/release_invalid_release_date.json
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "1997-07-22T21:31:03Z"
   }],
   "provisional_date": "May 1995"
 }

--- a/data/json_files/release_invalid_release_date.json
+++ b/data/json_files/release_invalid_release_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/economy/inflationandpriceindices/timeseries/ju37/mm22",
+  "uri": "/peoplepopulationandcommunity/healthandsocialcare/healthandlifeexpectancies/adhocs/2557lifeexpectancyatbirthforparliamentaryconstituenciesintheuk2022",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_invalid_topics.json
+++ b/data/json_files/release_invalid_topics.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/releases/industrytoindustrypaymentflowsuk2017to2024experimentaldata",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_invalid_topics.json
+++ b/data/json_files/release_invalid_topics.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2007-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "A Release with Invalid Topics",
   "topics": [
@@ -21,7 +21,7 @@
   "published": true,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "1997-07-22T21:31:03Z"
   }],
   "provisional_date": "July 1997"
 }

--- a/data/json_files/release_no_content_type_or_ids.json
+++ b/data/json_files/release_no_content_type_or_ids.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/businessindustryandtrade/business/activitysizeandlocation/adhocs/2555specialconstructioninstallationactivities2022to2024",
   "uri_old": "",
   "content_type": "",
   "cdid": "",

--- a/data/json_files/release_no_content_type_or_ids.json
+++ b/data/json_files/release_no_content_type_or_ids.json
@@ -6,7 +6,7 @@
   "dataset_id": "",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2007-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "A Release with No Content Type, CDID, or Dataset ID",
   "topics": [
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2006-07-22T21:31:03Z"
   }],
   "provisional_date": "September 1999"
 }

--- a/data/json_files/release_no_date_change.json
+++ b/data/json_files/release_no_date_change.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/news/statementsandletters/exceptionalprereleaseaccesstoofficefornationalstatisticsnationalpopulationprojections2022based",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_date_change.json
+++ b/data/json_files/release_no_date_change.json
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": ""
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "February 2007"
 }

--- a/data/json_files/release_no_edition_desc_or_summary.json
+++ b/data/json_files/release_no_edition_desc_or_summary.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "",
   "meta_description": "",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2008-07-22T21:31:03Z",
   "summary": "",
   "title": "A Release with No Edition, Meta Description, or Summary",
   "topics": [
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "November 2002"
 }

--- a/data/json_files/release_no_edition_desc_or_summary.json
+++ b/data/json_files/release_no_edition_desc_or_summary.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_edition_desc_or_summary.json
+++ b/data/json_files/release_no_edition_desc_or_summary.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202401",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_provisional_date.json
+++ b/data/json_files/release_no_provisional_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202402",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_provisional_date.json
+++ b/data/json_files/release_no_provisional_date.json
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "2011-03-01T00:00:00Z"
+    "previous_date": "2001-03-01T00:00:00Z"
   }],
   "provisional_date": ""
 }

--- a/data/json_files/release_no_provisional_date.json
+++ b/data/json_files/release_no_provisional_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_release_date_or_uris.json
+++ b/data/json_files/release_no_release_date_or_uris.json
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "January 2005"
 }

--- a/data/json_files/release_no_survey_or_can_topic.json
+++ b/data/json_files/release_no_survey_or_can_topic.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2017-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "A Release with No Survey or Canonical Topic",
   "topics": [
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "June 2009"
 }

--- a/data/json_files/release_no_survey_or_can_topic.json
+++ b/data/json_files/release_no_survey_or_can_topic.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202403",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_survey_or_can_topic.json
+++ b/data/json_files/release_no_survey_or_can_topic.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_title_or_lang.json
+++ b/data/json_files/release_no_title_or_lang.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2020-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "",
   "topics": [
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "August 2011"
 }

--- a/data/json_files/release_no_title_or_lang.json
+++ b/data/json_files/release_no_title_or_lang.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_title_or_lang.json
+++ b/data/json_files/release_no_title_or_lang.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202404",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_topics.json
+++ b/data/json_files/release_no_topics.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202405",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_no_topics.json
+++ b/data/json_files/release_no_topics.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "interesting edition",
   "meta_description": "interesting description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2009-07-22T21:31:03Z",
   "summary": "interesting summary",
   "title": "A Release with No Topics",
   "topics": [],
@@ -18,7 +18,7 @@
   "published": true,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "October 2013"
 }

--- a/data/json_files/release_no_topics.json
+++ b/data/json_files/release_no_topics.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/businessindustryandtrade/changestobusiness/businessbirthsdeathsandsurvivalrates/adhocs/14144demographyforscottishdistricts2020",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december2024",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_one_topic.json
+++ b/data/json_files/release_one_topic.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "this edition",
   "meta_description": "this description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2018-07-22T21:31:03Z",
   "summary": "this summary",
   "title": "A Release with a Single Topic",
   "topics": [
@@ -20,7 +20,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "December 2015"
 }

--- a/data/json_files/release_one_topic.json
+++ b/data/json_files/release_one_topic.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/economy/inflationandpriceindices/bulletins/housepriceindex/april2022",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending6december2024",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_past_date_change.json
+++ b/data/json_files/release_past_date_change.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/visualisations/dvc3143",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_past_provisional_date.json
+++ b/data/json_files/release_past_provisional_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/peoplepopulationandcommunity/crimeandjustice/datasets/womenwhohavesurviveddomesticabuseandtheirexperiencesoftemporarysafeaccommodationsampleinformation/current/previous/v1",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_past_release_date.json
+++ b/data/json_files/release_past_release_date.json
@@ -21,7 +21,7 @@
   "published": true,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "1993-07-22T21:31:03Z"
   }],
   "provisional_date": "February 2016"
 }

--- a/data/json_files/release_past_release_date.json
+++ b/data/json_files/release_past_release_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/economy/inflationandpriceindices/timeseries/ju37/mm22",
+  "uri": "/peoplepopulationandcommunity/populationandmigration/populationestimates/adhocs/2556ct210360census2021",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_two_topics.json
+++ b/data/json_files/release_two_topics.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2016-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "A Release with Two Topics",
   "topics": [
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "March 2018"
 }

--- a/data/json_files/release_two_topics.json
+++ b/data/json_files/release_two_topics.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/releases/businessinvestmentintheukstatisticsprogressreportjanuary2025",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_zero_date_change.json
+++ b/data/json_files/release_zero_date_change.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/peoplepopulationandcommunity/housing/adhocs/2523ct210358census2021",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_zero_provisional_date.json
+++ b/data/json_files/release_zero_provisional_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/businessindustryandtrade/business/activitysizeandlocation/adhocs/2530nationalforestareasofderbyshireleicestershireandstaffordshirebyuksic2007broadindustry",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/release_zero_release_date.json
+++ b/data/json_files/release_zero_release_date.json
@@ -21,7 +21,7 @@
   "published": false,
   "date_changes": [{
     "change_notice": "a change_notice",
-    "previous_date": "a previous_date"
+    "previous_date": "2007-07-22T21:31:03Z"
   }],
   "provisional_date": "June 2024"
 }

--- a/data/json_files/release_zero_release_date.json
+++ b/data/json_files/release_zero_release_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/businessindustryandtrade/changestobusiness/businessbirthsdeathsandsurvivalrates/adhocs/14144demographyforscottishdistricts2020",
+  "uri": "/businessindustryandtrade/business/activitysizeandlocation/adhocs/2554environmentalconsultingactivitiesfrom2022to2024",
   "uri_old": "",
   "content_type": "release",
   "cdid": "A321B",

--- a/data/json_files/standard_future_release_date.json
+++ b/data/json_files/standard_future_release_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/economy/inflationandpriceindices/bulletins/housepriceindex/april2022",
+  "uri": "/releases/redevelopmentofniprivaterentalstatisticsimpactanalysis",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_invalid_release_date.json
+++ b/data/json_files/standard_invalid_release_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/economy/inflationandpriceindices/timeseries/ju37/mm22",
+  "uri": "/releases/experiencesofnhshealthcareservicesinengland9january2025",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_invalid_topics.json
+++ b/data/json_files/standard_invalid_topics.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "some edition",
   "meta_description": "some description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2007-07-22T21:31:03Z",
   "summary": "some summary",
   "title": "A Standard Resource with Invalid Topics",
   "topics": [

--- a/data/json_files/standard_invalid_topics.json
+++ b/data/json_files/standard_invalid_topics.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/conceptionandfertilityrates/adhocs/2553livebirthsbygestationenglandandwales2014to2023",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_no_content_type_or_ids.json
+++ b/data/json_files/standard_no_content_type_or_ids.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/businessindustryandtrade/business/businessinnovation/methodologies/businessenterpriseresearchanddevelopmentqmi",
+  "uri": "/businessindustryandtrade/business/businessinnovation/methodologies/businessenterpriseresearchanddevelopmentqmi01",
   "uri_old": "",
   "content_type": "",
   "cdid": "",

--- a/data/json_files/standard_no_content_type_or_ids.json
+++ b/data/json_files/standard_no_content_type_or_ids.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/businessindustryandtrade/business/businessinnovation/methodologies/businessenterpriseresearchanddevelopmentqmi",
   "uri_old": "",
   "content_type": "",
   "cdid": "",

--- a/data/json_files/standard_no_content_type_or_ids.json
+++ b/data/json_files/standard_no_content_type_or_ids.json
@@ -6,7 +6,7 @@
   "dataset_id": "",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2007-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "A Standard Resource with No Content Type, CDID, or Dataset ID",
   "topics": [

--- a/data/json_files/standard_no_edition_desc_or_summary.json
+++ b/data/json_files/standard_no_edition_desc_or_summary.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/aboutus/whatwedo/programmesandprojects/playmypart",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_no_edition_desc_or_summary.json
+++ b/data/json_files/standard_no_edition_desc_or_summary.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "",
   "meta_description": "",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2007-07-22T21:31:03Z",
   "summary": "",
   "title": "A Standard Resource with No Edition, Meta Description, or Summary",
   "topics": [

--- a/data/json_files/standard_no_survey_or_can_topic.json
+++ b/data/json_files/standard_no_survey_or_can_topic.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2007-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "A Standard Resource with No Survey or Canonical Topic",
   "topics": [

--- a/data/json_files/standard_no_survey_or_can_topic.json
+++ b/data/json_files/standard_no_survey_or_can_topic.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/aboutus/whatwedo/statistics/requestingstatistics/secureresearchservice/gettingyourresearchoutputsapproved",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_no_title_or_lang.json
+++ b/data/json_files/standard_no_title_or_lang.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/surveys/informationforbusinesses",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_no_title_or_lang.json
+++ b/data/json_files/standard_no_title_or_lang.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2007-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "",
   "topics": [

--- a/data/json_files/standard_no_topics.json
+++ b/data/json_files/standard_no_topics.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2007-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "A Standard Resource with No Topics",
   "topics": [],

--- a/data/json_files/standard_no_topics.json
+++ b/data/json_files/standard_no_topics.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/businessindustryandtrade/changestobusiness/businessbirthsdeathsandsurvivalrates/adhocs/14144demographyforscottishdistricts2020",
+  "uri": "/businessindustryandtrade/business/businessinnovation/methodologies/businessenterpriseresearchanddevelopmentqmi",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_no_topics.json
+++ b/data/json_files/standard_no_topics.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/businessindustryandtrade/business/businessinnovation/methodologies/businessenterpriseresearchanddevelopmentqmi",
+  "uri": "/businessindustryandtrade/business/businessinnovation/methodologies/businessenterpriseresearchanddevelopmentqmi02",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_one_topic.json
+++ b/data/json_files/standard_one_topic.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/economy/inflationandpriceindices/bulletins/housepriceindex/april2022",
+  "uri": "/aboutus/transparencyandgovernance/freedomofinformationfoi/multiethnicityhouseholdsintheuk",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_one_topic.json
+++ b/data/json_files/standard_one_topic.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "interesting edition",
   "meta_description": "interesting description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2008-07-22T21:31:03Z",
   "summary": "interesting summary",
   "title": "A Standard Resource with One Topic",
   "topics": [

--- a/data/json_files/standard_past_release_date.json
+++ b/data/json_files/standard_past_release_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/economy/inflationandpriceindices/timeseries/ju37/mm22",
+  "uri": "/aboutus/imfpage",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_two_topics.json
+++ b/data/json_files/standard_two_topics.json
@@ -6,7 +6,7 @@
   "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
   "edition": "latest edition",
   "meta_description": "latest description",
-  "release_date": "0001-02-01T00:00:00Z",
+  "release_date": "2009-07-22T21:31:03Z",
   "summary": "latest summary",
   "title": "A Standard Resource with Two Topics",
   "topics": [

--- a/data/json_files/standard_two_topics.json
+++ b/data/json_files/standard_two_topics.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
+  "uri": "/aboutus/transparencyandgovernance/freedomofinformationfoi/childreninenglandandwalesbyethnicityofbothparents",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/data/json_files/standard_zero_release_date.json
+++ b/data/json_files/standard_zero_release_date.json
@@ -1,5 +1,5 @@
 {
-  "uri": "/businessindustryandtrade/changestobusiness/businessbirthsdeathsandsurvivalrates/adhocs/14144demographyforscottishdistricts2020",
+  "uri": "/employmentandlabourmarket/peopleinwork/earningsandworkinghours/adhocs/2552annualsurveyofhoursandearningsasheestimatesofgrossannualearningsby4digitoccupation2023and2024",
   "uri_old": "",
   "content_type": "standard",
   "cdid": "A321B",

--- a/features/steps/example_resources.json
+++ b/features/steps/example_resources.json
@@ -1,584 +1,584 @@
 {
-    "count": 20,
-    "items": [
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "2010-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with A Change Notice for a Future Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "2059-07-01T12:07:20Z"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "March 1991",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "2010-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with a Future Provisional Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "2019-07-01T12:07:20Z"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "July 2059",
-        "published": false
-      },
-      {
-        "canonical_topic": "future canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "future edition",
-        "language": "future language",
-        "meta_description": "future description",
-        "release_date": "2997-07-22T21:31:03Z",
-        "summary": "future summary",
-        "survey": "future survey",
-        "title": "A Release with a Future Release Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/economy/inflationandpriceindices/bulletins/housepriceindex/april2022",
-        "uri_old": "",
-        "cancelled": true,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "March 1991",
-        "published": true
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "2010-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with A Change Notice for an Invalid Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "an invalid date"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "April 1993",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "2010-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with an Invalid Provisional Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "an invalid date"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "bananas",
-        "published": false
-      },
-      {
-        "canonical_topic": "some canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "some edition",
-        "language": "some language",
-        "meta_description": "some description",
-        "release_date": "an invalid date",
-        "summary": "some summary",
-        "survey": "some survey",
-        "title": "A Release with an Invalid Release Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/economy/inflationandpriceindices/timeseries/ju37/mm22",
-        "uri_old": "",
-        "cancelled": true,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "May 1995",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "0001-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with Invalid Topics",
-        "topics": [
-          "an-invalid-topic",
-          "another-invalid-topic"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": true,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": false,
-        "provisional_date": "July 1997",
-        "published": true
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "",
-        "content_type": "",
-        "dataset_id": "",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "0001-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with No Content Type, CDID, or Dataset ID",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "September 1999",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "2010-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with A Change Notice for an Empty Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": ""
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "February 2007",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "",
-        "language": "latest language",
-        "meta_description": "",
-        "release_date": "0001-02-01T00:00:00Z",
-        "summary": "",
-        "survey": "latest survey",
-        "title": "A Release with No Edition, Meta Description, or Summary",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": true,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": false,
-        "provisional_date": "November 2002",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "2010-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with no Provisional Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "2011-03-01T00:00:00Z"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with No Release Date, URI, or URI_Old",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "",
-        "uri_old": "",
-        "cancelled": true,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": false,
-        "provisional_date": "January 2005",
-        "published": false
-      },
-      {
-        "canonical_topic": "",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "0001-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "",
-        "title": "A Release with No Survey or Canonical Topic",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": true,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": false,
-        "provisional_date": "June 2009",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "",
-        "meta_description": "latest description",
-        "release_date": "0001-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": true,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": false,
-        "provisional_date": "August 2011",
-        "published": false
-      },
-      {
-        "canonical_topic": "interesting canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "interesting edition",
-        "language": "interesting language",
-        "meta_description": "interesting description",
-        "release_date": "0001-02-01T00:00:00Z",
-        "summary": "interesting summary",
-        "survey": "interesting survey",
-        "title": "A Release with No Topics",
-        "topics": [],
-        "uri": "/businessindustryandtrade/changestobusiness/businessbirthsdeathsandsurvivalrates/adhocs/14144demographyforscottishdistricts2020",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "October 2013",
-        "published": true
-      },
-      {
-        "canonical_topic": "this canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "this edition",
-        "language": "this language",
-        "meta_description": "this description",
-        "release_date": "0001-02-01T00:00:00Z",
-        "summary": "this summary",
-        "survey": "this survey",
-        "title": "A Release with a Single Topic",
-        "topics": [
-          "4972"
-        ],
-        "uri": "/economy/inflationandpriceindices/bulletins/housepriceindex/april2022",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": false,
-        "provisional_date": "December 2015",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "2010-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with A Change Notice for a Past Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "2009-07-01T12:07:20Z"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "January 2014",
-        "published": false
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "2021-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with a Past Provisional Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "2009-07-01T12:07:20Z"
-          }
-        ],
-        "finalised": true,
-        "provisional_date": "March 2011",
-        "published": false
-      },
-      {
-        "canonical_topic": "past canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "past edition",
-        "language": "past language",
-        "meta_description": "past description",
-        "release_date": "1997-07-22T21:31:03Z",
-        "summary": "past summary",
-        "survey": "past survey",
-        "title": "A Release with a Past Release Date",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/economy/inflationandpriceindices/timeseries/ju37/mm22",
-        "uri_old": "",
-        "cancelled": false,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": false,
-        "provisional_date": "February 2016",
-        "published": true
-      },
-      {
-        "canonical_topic": "latest canonical topic",
-        "cdid": "A321B",
-        "content_type": "release",
-        "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
-        "edition": "latest edition",
-        "language": "latest language",
-        "meta_description": "latest description",
-        "release_date": "0001-02-01T00:00:00Z",
-        "summary": "latest summary",
-        "survey": "latest survey",
-        "title": "A Release with Two Topics",
-        "topics": [
-          "4972",
-          "1245"
-        ],
-        "uri": "/employmentandlabourmarket/peoplenotinwork/unemployment/datasets/unemploymentbypreviousoccupationunem02",
-        "uri_old": "",
-        "cancelled": true,
-        "date_changes": [
-          {
-            "change_notice": "a change_notice",
-            "previous_date": "a previous_date"
-          }
-        ],
-        "finalised": false,
-        "provisional_date": "March 2018",
-        "published": false
-      }
-    ],
-    "limit": 20,
-    "offset": 0,
-    "total_count": 36
-  }
+  "count": 20,
+  "items": [
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2010-02-01T00:00:00Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with A Change Notice for a Future Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/peoplepopulationandcommunity/healthandsocialcare/drugusealcoholandsmoking",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2059-07-01T12:07:20Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "March 1991",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2010-02-01T00:00:00Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with a Future Provisional Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/economy/governmentpublicsectorandtaxes/taxesandrevenue/adhocs/2550taxesandsubsidiesonproductsandproductionbyindustry",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2019-07-01T12:07:20Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "July 2059",
+      "published": false
+    },
+    {
+      "canonical_topic": "future canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "future edition",
+      "language": "future language",
+      "meta_description": "future description",
+      "release_date": "2997-07-22T21:31:03Z",
+      "summary": "future summary",
+      "survey": "future survey",
+      "title": "A Release with a Future Release Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/releases/financeandhousingukarmedforcesveteransveteranssurvey2022uk",
+      "uri_old": "",
+      "cancelled": true,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2097-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "March 1991",
+      "published": true
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2010-02-01T00:00:00Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with A Change Notice for an Invalid Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/adhocs/2559onslocaloverviewofcreativejobsandcreativeindustriessoutheastofengland2014to2023",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "an invalid date"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "April 1993",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2010-02-01T00:00:00Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with an Invalid Provisional Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/employmentandlabourmarket/peopleinwork/earningsandworkinghours/adhocs/2558annualsurveyofhoursandearningsasheestimatesofgrossannualearningsforregionby2digitoccupation2024",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "an invalid date"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "bananas",
+      "published": false
+    },
+    {
+      "canonical_topic": "some canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "some edition",
+      "language": "some language",
+      "meta_description": "some description",
+      "release_date": "an invalid date",
+      "summary": "some summary",
+      "survey": "some survey",
+      "title": "A Release with an Invalid Release Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/peoplepopulationandcommunity/healthandsocialcare/healthandlifeexpectancies/adhocs/2557lifeexpectancyatbirthforparliamentaryconstituenciesintheuk2022",
+      "uri_old": "",
+      "cancelled": true,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "1997-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "May 1995",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2007-07-22T21:31:03Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with Invalid Topics",
+      "topics": [
+        "an-invalid-topic",
+        "another-invalid-topic"
+      ],
+      "uri": "/releases/industrytoindustrypaymentflowsuk2017to2024experimentaldata",
+      "uri_old": "",
+      "cancelled": true,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "1997-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": false,
+      "provisional_date": "July 1997",
+      "published": true
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "",
+      "content_type": "",
+      "dataset_id": "",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2007-07-22T21:31:03Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with No Content Type, CDID, or Dataset ID",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/businessindustryandtrade/business/activitysizeandlocation/adhocs/2555specialconstructioninstallationactivities2022to2024",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2006-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "September 1999",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2010-02-01T00:00:00Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with A Change Notice for an Empty Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/news/statementsandletters/exceptionalprereleaseaccesstoofficefornationalstatisticsnationalpopulationprojections2022based",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2007-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "February 2007",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "",
+      "language": "latest language",
+      "meta_description": "",
+      "release_date": "2008-07-22T21:31:03Z",
+      "summary": "",
+      "survey": "latest survey",
+      "title": "A Release with No Edition, Meta Description, or Summary",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202401",
+      "uri_old": "",
+      "cancelled": true,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2007-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": false,
+      "provisional_date": "November 2002",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2010-02-01T00:00:00Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with no Provisional Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202402",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2001-03-01T00:00:00Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with No Release Date, URI, or URI_Old",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "",
+      "uri_old": "",
+      "cancelled": true,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2007-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": false,
+      "provisional_date": "January 2005",
+      "published": false
+    },
+    {
+      "canonical_topic": "",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2017-07-22T21:31:03Z",
+      "summary": "latest summary",
+      "survey": "",
+      "title": "A Release with No Survey or Canonical Topic",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202403",
+      "uri_old": "",
+      "cancelled": true,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2007-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": false,
+      "provisional_date": "June 2009",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "",
+      "meta_description": "latest description",
+      "release_date": "2020-07-22T21:31:03Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202404",
+      "uri_old": "",
+      "cancelled": true,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2007-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": false,
+      "provisional_date": "August 2011",
+      "published": false
+    },
+    {
+      "canonical_topic": "interesting canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "interesting edition",
+      "language": "interesting language",
+      "meta_description": "interesting description",
+      "release_date": "2009-07-22T21:31:03Z",
+      "summary": "interesting summary",
+      "survey": "interesting survey",
+      "title": "A Release with No Topics",
+      "topics": [],
+      "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending13december202405",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2007-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "October 2013",
+      "published": true
+    },
+    {
+      "canonical_topic": "this canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "this edition",
+      "language": "this language",
+      "meta_description": "this description",
+      "release_date": "2018-07-22T21:31:03Z",
+      "summary": "this summary",
+      "survey": "this survey",
+      "title": "A Release with a Single Topic",
+      "topics": [
+        "4972"
+      ],
+      "uri": "/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/deathsregisteredweeklyinenglandandwalesprovisional/weekending6december2024",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2007-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": false,
+      "provisional_date": "December 2015",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2010-02-01T00:00:00Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with A Change Notice for a Past Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/visualisations/dvc3143",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2009-07-01T12:07:20Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "January 2014",
+      "published": false
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2021-02-01T00:00:00Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with a Past Provisional Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/peoplepopulationandcommunity/crimeandjustice/datasets/womenwhohavesurviveddomesticabuseandtheirexperiencesoftemporarysafeaccommodationsampleinformation/current/previous/v1",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2009-07-01T12:07:20Z"
+        }
+      ],
+      "finalised": true,
+      "provisional_date": "March 2011",
+      "published": false
+    },
+    {
+      "canonical_topic": "past canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "past edition",
+      "language": "past language",
+      "meta_description": "past description",
+      "release_date": "1997-07-22T21:31:03Z",
+      "summary": "past summary",
+      "survey": "past survey",
+      "title": "A Release with a Past Release Date",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/peoplepopulationandcommunity/populationandmigration/populationestimates/adhocs/2556ct210360census2021",
+      "uri_old": "",
+      "cancelled": false,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "1993-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": false,
+      "provisional_date": "February 2016",
+      "published": true
+    },
+    {
+      "canonical_topic": "latest canonical topic",
+      "cdid": "A321B",
+      "content_type": "release",
+      "dataset_id": "ASELECTIONOFNUMBERSANDLETTERS456",
+      "edition": "latest edition",
+      "language": "latest language",
+      "meta_description": "latest description",
+      "release_date": "2016-07-22T21:31:03Z",
+      "summary": "latest summary",
+      "survey": "latest survey",
+      "title": "A Release with Two Topics",
+      "topics": [
+        "4972",
+        "1245"
+      ],
+      "uri": "/releases/businessinvestmentintheukstatisticsprogressreportjanuary2025",
+      "uri_old": "",
+      "cancelled": true,
+      "date_changes": [
+        {
+          "change_notice": "a change_notice",
+          "previous_date": "2007-07-22T21:31:03Z"
+        }
+      ],
+      "finalised": false,
+      "provisional_date": "March 2018",
+      "published": false
+    }
+  ],
+  "limit": 20,
+  "offset": 0,
+  "total_count": 36
+}

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -18,22 +18,22 @@ var _ sdk.Clienter = &ClienterMock{}
 
 // ClienterMock is a mock implementation of sdk.Clienter.
 //
-//	func TestSomethingThatUsesClienter(t *testing.T) {
+// 	func TestSomethingThatUsesClienter(t *testing.T) {
 //
-//		// make and configure a mocked sdk.Clienter
-//		mockedClienter := &ClienterMock{
-//			CheckerFunc: func(ctx context.Context, check *health.CheckState) error {
-//				panic("mock out the Checker method")
-//			},
-//			GetResourcesFunc: func(ctx context.Context, options sdk.Options) (*models.Resources, apiError.Error) {
-//				panic("mock out the GetResources method")
-//			},
-//		}
+// 		// make and configure a mocked sdk.Clienter
+// 		mockedClienter := &ClienterMock{
+// 			CheckerFunc: func(ctx context.Context, check *health.CheckState) error {
+// 				panic("mock out the Checker method")
+// 			},
+// 			GetResourcesFunc: func(ctx context.Context, options sdk.Options) (*models.Resources, apiError.Error) {
+// 				panic("mock out the GetResources method")
+// 			},
+// 		}
 //
-//		// use mockedClienter in code that requires sdk.Clienter
-//		// and then make assertions.
+// 		// use mockedClienter in code that requires sdk.Clienter
+// 		// and then make assertions.
 //
-//	}
+// 	}
 type ClienterMock struct {
 	// CheckerFunc mocks the Checker method.
 	CheckerFunc func(ctx context.Context, check *health.CheckState) error
@@ -82,8 +82,7 @@ func (mock *ClienterMock) Checker(ctx context.Context, check *health.CheckState)
 
 // CheckerCalls gets all the calls that were made to Checker.
 // Check the length with:
-//
-//	len(mockedClienter.CheckerCalls())
+//     len(mockedClienter.CheckerCalls())
 func (mock *ClienterMock) CheckerCalls() []struct {
 	Ctx   context.Context
 	Check *health.CheckState
@@ -118,8 +117,7 @@ func (mock *ClienterMock) GetResources(ctx context.Context, options sdk.Options)
 
 // GetResourcesCalls gets all the calls that were made to GetResources.
 // Check the length with:
-//
-//	len(mockedClienter.GetResourcesCalls())
+//     len(mockedClienter.GetResourcesCalls())
 func (mock *ClienterMock) GetResourcesCalls() []struct {
 	Ctx     context.Context
 	Options sdk.Options


### PR DESCRIPTION
### What

These changes to the test data allow the Search Upstream Stub to be used by the Search Reindex Batch service without producing too many parsing errors (except where data is deliberately invalid) or version conflicts from duplicate URI values.

### How to review

cd dis-search-upstream-stub
git pull
make debug

Check that this endpoint returns 20 resources, which look ok: http://localhost:29600/resources

### Who can review

!me