### PR TITLE
Remove search_index from SearchContentUpdatedResource

### DIFF
--- a/models/resource.go
+++ b/models/resource.go
@@ -10,7 +10,7 @@ type Resource interface {
 	GetResourceType() string
 }
 
-// Custom unmarshalling for Resources
+// UnmarshalJSON provides custom unmarshalling for Resources
 func (r *Resources) UnmarshalJSON(data []byte) error {
 	// Define a temporary structure for unmarshalling
 	var aux struct {
@@ -92,7 +92,6 @@ type SearchContentUpdatedResource struct {
 	ReleaseDate     string   `avro:"release_date" json:"release_date"`
 	Summary         string   `avro:"summary" json:"summary"`
 	Survey          string   `avro:"survey" json:"survey"`
-	SearchIndex     string   `avro:"search_index" json:"search_index"`
 	TraceID         string   `avro:"trace_id" json:"trace_id"`
 	Title           string   `avro:"title" json:"title"`
 	Topics          []string `avro:"topics" json:"topics"`


### PR DESCRIPTION
### What

Jira ticket: https://officefornationalstatistics.atlassian.net/jira/software/c/projects/DIS/boards/1824?selectedIssue=DIS-3620

The above ticket has been mostly completed already by this PR: https://github.com/ONSdigital/dp-search-data-extractor/pull/143

The very last part of the ticket is to ensure the stub gets updated, which is what this PR is for: 

When creating search-content-updated messages the Stub no longer needs to include the search_index, so this has been removed.

### How to review

Sense check and make sure that the tests pass.

### Who can review

Anyone.